### PR TITLE
Fix code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/frontend/src/components/funcs/showKanaFunc.ts
+++ b/frontend/src/components/funcs/showKanaFunc.ts
@@ -30,12 +30,12 @@ export const updateKanaWeight = async (
       // Update weights based on the fetched data
       return updateWeights(initialKanaCharacters, data, kanaType);
     } catch (updateError) {
-      console.error(`Error updating weights for ${kanaType}:`, updateError);
+      console.error("Error updating weights for %s:", kanaType, updateError);
       // Return the original list with initial weights if weight update fails
       return initialKanaCharacters;
     }
   } catch (fetchError) {
-    console.error(`Error fetching ${kanaType} data:`, fetchError);
+    console.error("Error fetching %s data:", kanaType, fetchError);
     // Return the original list with initial weights if fetch fails
     return initialKanaCharacters;
   }


### PR DESCRIPTION
Fixes [https://github.com/sakan811/kana-flashcard-web-app/security/code-scanning/2](https://github.com/sakan811/kana-flashcard-web-app/security/code-scanning/2)

To fix the problem, we should ensure that the `kanaType` parameter is safely included in the log message. This can be achieved by using a `%s` specifier in the format string and passing the `kanaType` as a separate argument to `console.error`. This approach ensures that any format specifiers in `kanaType` are treated as plain text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
